### PR TITLE
Share logic to normalize paths to Unix style

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ let getLayers = require('./get-layers')
 let getRuntime = require('./get-runtime')
 let init = require('./init')
 let inventory = require('./inventory')
+let pathToUnix = require('./path-to-unix')
 let populateEnv = require('./populate-env')
 let portInUse = require('./port-in-use')
 let readArc = require('./read-arc')
@@ -21,6 +22,7 @@ module.exports = {
   getRuntime,     // Get runtime config from Arc file or config
   init,           // Boilerplate code generator for Arc projects
   inventory,      // Get inventory of current AWS resources from Arc file
+  pathToUnix,     // Use / seperated paths everywhere
   populateEnv,    // Populate env vars from .arc-env config
   portInUse,      // Checks to see if a port is in use
   readArc,        // Reads Arc file and returns raw + parsed versions

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run lint && npm run test:unit",
     "test:unit": "tape test/*-test.js | tap-spec",
     "coverage": "istanbul cover tape test/*-test.js",
-    "lint": "eslint ."
+    "lint": "npx eslint ."
   },
   "author": "Brian LeRoux <b@brian.io>",
   "license": "Apache-2.0",

--- a/path-to-unix.js
+++ b/path-to-unix.js
@@ -1,0 +1,7 @@
+// Just use Unix seperators on Windows
+// We do this because `path.posix.normalize(process.cwd())`
+// returns C:\\foo\\bar, we just want C:/foo/bar
+// We normalise to slash file names (C:/foo/bar) for regex tests, etc.
+module.exports = function pathToUnix(string) {
+  return string.replace(/\\/g, "/");
+}

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,11 @@ Returns an object containing:
 The returned object is based on the provided `arc` argument, which should be a
 parsed `.arc` file (or will attempt to parse one if none is passed).
 
+## `utils.pathToUnix(pathString)`
+
+Comverts any path to a Unix style path, with '/' as the seperator. This works
+around Windows issues where '/' is assumed across other parts of Architect.
+
 ## `utils.populateEnv(callback)`
 
 Populates the runtime environment with variables from a `.arc-env` if present.

--- a/test/path-to-unix-test.js
+++ b/test/path-to-unix-test.js
@@ -1,0 +1,11 @@
+let test = require('tape')
+let pathToUnix = require('../path-to-unix')
+
+test('path-to-unix returns / seperated paths on Windows', t => {
+  t.plan(1)
+  t.equals(pathToUnix('C:\\Users\\user'), 'C:/Users/user', 'pathToUnix returns / seperated paths on Windows')
+})
+test('path-to-unix returns / seperated paths on Unix', t => {
+  t.plan(1)
+  t.equals(pathToUnix('/home/user'), '/home/user', 'pathToUnix returns / seperated paths on Windows')
+})


### PR DESCRIPTION
This is needed in both `sandbox` and `hydrate`

Includes tests etc.

Relates to https://github.com/architect/hydrate/issues/24