### PR TITLE
Aids in restoring cursor when user quits an Architect workflow

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.5.2] 2020-04-07
+
+### Fixed
+
+- Should now restore cursor more reliably when a user quits any workflow that's using `updater`
+
+---
+
 ## [1.5.1 - 1.5.2] 2020-03-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/utils",
-  "version": "1.5.2",
+  "version": "1.5.3-RC.0",
   "description": "Common utility functions",
   "main": "index.js",
   "repository": {

--- a/updater/index.js
+++ b/updater/index.js
@@ -123,3 +123,10 @@ module.exports = function updater(name, params={quiet:false}) {
     warning: warn
   }
 }
+
+// For whatever reason signal-exit doesn't catch SIGINT, so do this
+process.on('SIGINT', () => {
+  printer.restoreCursor()
+  console.log('')
+  process.exit()
+})


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
