### PR TITLE
Inventory custom ws routes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.5.3] 2020-04-22
+
+### Fixed
+
+- Inventory correctly reports custom websocket routes
+
+---
+
 ## [1.5.2] 2020-04-07
 
 ### Fixed

--- a/inventory/index.js
+++ b/inventory/index.js
@@ -105,28 +105,19 @@ module.exports = function inventory(arc) {
     let wsName = name => process.env.DEPRECATED ? `ws-${name}` : name
     let dir = name => path.join('src', 'ws', wsName(name))
 
-    report.websocketapis = [
-      `${app}-ws-staging`,
-      `${app}-ws-production`,
-    ]
-    report.lambdas = report.lambdas.concat([
-      `${app}-staging-ws-default`,
-      `${app}-staging-ws-connect`,
-      `${app}-staging-ws-disconnect`,
-      `${app}-production-ws-default`,
-      `${app}-production-ws-connect`,
-      `${app}-production-ws-disconnect`,
-    ])
-    report.types.ws = [
-      wsName('default'),
-      wsName('connect'),
-      wsName('disconnect'),
-    ]
-    report.localPaths = report.localPaths.concat([
-      dir('default'),
-      dir('connect'),
-      dir('disconnect'),
-    ])
+    const infras = ['staging', 'production']
+    const routes = ['default', 'connect', 'disconnect'].concat(arc.ws)
+
+    report.types.ws = routes.map(wsName)
+
+    report.localPaths = report.localPaths.concat(routes.map(dir))
+
+    report.websocketapis = infras.map(infra => `${app}-ws-${infra}`)
+
+    infras.forEach(infra => {
+      const lambdas = routes.map(route => `${app}-${infra}-ws-${route}`)
+      report.lambdas = report.lambdas.concat(lambdas)
+    })
   }
 
   if (arc.events && arc.events.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/utils",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Common utility functions",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
When specifying custom websocket routes, the dependencies don't get hydrated because their paths don't appear in the inventory: https://github.com/architect/hydrate/blob/26f0cf2e753cd839dcd7f5990df5002cee66a993/src/install.js#L91

Steps to reproduce:
1. Specify a custom websocket route:
```
@ws
myRoute
```
2. Add a package.json to the lambda with a dependency (do not `npm i`):
```
{
  "name": "myRoute",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "dependencies": {
    "uuid": "^7.0.3"
  }
}
```
3. Add some code to index.js:
```javascript
const { v4: uuid } = require("uuid");
exports.handler = async function ws() {
  uuid();
}
```
4. `arc deploy` - you can see in the output that the route is not hydrated
5. Hit your function :boom:

This change correctly populates the inventory with custom route goodness.

Would've added tests, but there weren't any for this function 😢 

Let me know if there's anything I've missed / done wrong with this PR, cheers!

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ x] Forked the repo and created your branch from `master`
- [ x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
