### PR TITLE
`getLambdaName` now normalizes backslash characters as well

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [2.0.5] 2021-03-05
+
+### Changed
+
+- `getLambdaName` now sanitizes backslash characters to hyphens
+
+---
+
 ## [2.0.4] 2021-01-05
 
 ### Added

--- a/get-lambda-name/index.js
+++ b/get-lambda-name/index.js
@@ -22,6 +22,7 @@ module.exports = function getLambdaName (fn) {
       .replace(/\./g, '_')
       .replace(/_/g,  '_')
       .replace(/\//g, '-')
+      .replace(/\\/g, '-')
       .replace(/:/g,  '000')
       .replace(/\*/,  'catchall')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/utils",
-  "version": "2.0.4",
+  "version": "2.0.5-RC.0",
   "description": "Common utility functions",
   "main": "index.js",
   "repository": {

--- a/test/get-lambda-name/index-test.js
+++ b/test/get-lambda-name/index-test.js
@@ -2,7 +2,7 @@ let test = require('tape')
 let name = require('../../get-lambda-name')
 
 test('get-lambda-name converts routes to acceptable names', t => {
-  t.plan(7)
+  t.plan(8)
   t.equals(name('/'), '-index', 'root route returns -index')
   t.equals(name('/memories'), '-memories', 'named base route converts slashes')
   t.equals(name('/batman/robin'), '-batman-robin', 'intermediate slashes are converted to dashes')
@@ -10,4 +10,5 @@ test('get-lambda-name converts routes to acceptable names', t => {
   t.equals(name('/batman-robin'), '-batman_robin', 'dashes are converted to underscores')
   t.equals(name('/:batman'), '-000batman', 'colons are converted to triple zeros')
   t.equals(name('/path/*'), '-path-catchall', '* is converted to catchall')
+  t.equals(name('\\path\\*'), '-path-catchall', 'windows path slashes are converted appropriately')
 })


### PR DESCRIPTION
Needed for plugins stuff.