### PR TITLE
fix: toLogicalID ensures its a string

### DIFF
--- a/to-logical-id/index.js
+++ b/to-logical-id/index.js
@@ -2,7 +2,7 @@
  * convert .arc typical dash-case-stuff into PascalCaseStuff
  */
 module.exports = function toLogicalID (str) {
-  str = str.replace(/([A-Z])/g, ' $1')
+  str = str.toString().replace(/([A-Z])/g, ' $1')
   if (str.length === 1)
     return str.toUpperCase()
   str = str.replace(/^[\W_]+|[\W_]+$/g, '').toLowerCase()


### PR DESCRIPTION
This fixed a problem related to `arc-destroy`, where the `--name` argument was a number, which apparently arrives in this function as a JS number.