### PR TITLE
toLocalID tests

### DIFF
--- a/test/to-logical-id/index-test.js
+++ b/test/to-logical-id/index-test.js
@@ -1,0 +1,22 @@
+let test = require('tape')
+let toLogicalID = require('../../to-logical-id')
+
+test('Get', t => {
+  t.plan(4)
+  t.equals(toLogicalID('get'), 'GetIndex', 'get returns GetIndex')
+  t.equals(toLogicalID('Get'), 'GetIndex', 'Get returns GetIndex')
+  t.equals(toLogicalID('getIndex'), 'GetIndex', 'GetIndex returns GetIndex')
+  t.equals(toLogicalID('GetIndex'), 'GetIndex', 'GetIndex returns GetIndex')
+})
+
+test('App and environment', t => {
+  t.plan(2)
+  t.equals(toLogicalID('my-app-staging'), 'MyAppStaging', 'my-app-staging returns MyAppStaging')
+  t.equals(toLogicalID('my-app-production'), 'MyAppProduction', 'my-app-production returns MyAppProduction')
+})
+
+test('numerical app name', t => {
+  t.plan(2)
+  t.equals(toLogicalID('1234'), '1234', '"1234" returns "1234"')
+  t.equals(toLogicalID(1234), '1234', '1234 returns "1234"')
+})


### PR DESCRIPTION
A user reported a problem running `arc-destroy --app decipad-backend --name "$NAME" --force`.

https://discord.com/channels/880272256100601927/884128391341678742/974595660844240906

It produced the following stack trace:

```
⚬ Destroy Destroying staging environment
⚬ Destroy Reminder: if you deployed to production, don't forget to run destroy again with: --production
× TypeError: str.replace is not a function
TypeError: 
    at toLogicalID (/home/runner/work/decipad/decipad/node_modules/@architect/utils/to-logical-id/index.js:5:13)
    at destroy (/home/runner/work/decipad/decipad/node_modules/@architect/destroy/src/index.js:35:18)
    at main (/home/runner/work/decipad/decipad/node_modules/@architect/destroy/src/cli.js:45:11)
    at /home/runner/work/decipad/decipad/node_modules/@architect/destroy/src/cli.js:75:13
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

The root cause was the $NAME was a number, so when `toLogicalID` was called from `@architect/destroy` things blew up. The previous commit fixes the problem and these are additional tests.

I wanted to get some extra eyes on this just to make sure this change to `utils` won't break anything.


